### PR TITLE
Patch for #8587

### DIFF
--- a/library/Pnp4nagios/Grapher.php
+++ b/library/Pnp4nagios/Grapher.php
@@ -186,7 +186,7 @@ class Grapher extends GrapherHook
             '%s on %s, %s', $service, $host, $viewName
         );
 
-        $url = Url::fromPath('pnp4nagios', array(
+        $pageurl = Url::fromPath($this->baseUrl. '/graph' , array(
             'host' => $this->pnpClean($host),
             'srv' => $this->pnpClean($service),
             'view' => $view
@@ -203,7 +203,7 @@ class Grapher extends GrapherHook
 
         return sprintf(
             $html,
-            $url,
+            $pageurl,
             htmlspecialchars($title),
             $imgUrl,
             htmlspecialchars($viewName)

--- a/library/Pnp4nagios/Grapher.php
+++ b/library/Pnp4nagios/Grapher.php
@@ -186,24 +186,25 @@ class Grapher extends GrapherHook
             '%s on %s, %s', $service, $host, $viewName
         );
 
-        $pageurl = Url::fromPath($this->baseUrl. '/graph' , array(
+        $pageUrl = Url::fromPath($this->baseUrl. '/graph' , array(
             'host' => $this->pnpClean($host),
             'srv' => $this->pnpClean($service),
             'view' => $view
         ));
-        $imgUrl = sprintf(
-            '%s/image?host=%s&srv=%s&view=%d&source=0&w=120&h=30',
-            $this->baseUrl,
-            urlencode($this->pnpClean($host)),
-            urlencode($this->pnpClean($service)),
-            $view
-        );
+        $imgUrl = Url::fromPath($this->baseUrl. '/image' , array(
+            'host' => $this->pnpClean($host),
+            'srv' => $this->pnpClean($service),
+            'view' => $view,
+            'source' => 0,
+            'w' => 120,
+            'h' => 30
+        ));
 
         $html = '<a href="%s" title="%s"><img src="%s" alt="%s" width="100%%" height="30" /></a>';
 
         return sprintf(
             $html,
-            $pageurl,
+            $pageUrl,
             htmlspecialchars($title),
             $imgUrl,
             htmlspecialchars($viewName)


### PR DESCRIPTION
This resolves the mis-directed link URL which was going to the pnp4nagios base url, not the page where the actual graphs are found.

This also standardizes the link construction method between the pageUrl and the imageUrl.
